### PR TITLE
Updated the three.js dependency to allow the use of Raycaster.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "ngraph.forcelayout3d": "0.0.15",
     "ngraph.merge": "0.0.1",
-    "three": "0.68.0",
+    "three": "0.72.0",
     "three.trackball": "0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello again.

I updated the three.js dependency because I want to use Raycaster which is not supported in three r68.
This should not affect the behaviour of ngraph.three.

Best,
Dennis
