### PR TITLE
Feature - Change threejs to peer dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var THREE = require('./lib/three');
+var THREE = require('three');
 
 module.exports = function (graph, settings) {
   var merge = require('ngraph.merge');

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -2,7 +2,7 @@
  * This module provides default settings for three.js graphics. There are a lot
  * of possible configuration parameters, and this file provides reasonable defaults
  */
-var THREE = require('./three');
+var THREE = require('three');
 
 /**
  * Default node UI creator. Renders a cube

--- a/lib/three.js
+++ b/lib/three.js
@@ -1,1 +1,0 @@
-module.exports = require('three/three.min');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "3D graph rendered powered by three.js",
   "main": "index.js",
   "scripts": {
-    "examples": "cd ./example/basic && browserify -s ngraph index.js  > bundle.js; cd ../dynamic && browserify -s ngraph index.js  > bundle.js"
+    "peers": "npm-install-peers",
+    "examples": "npm run peers && cd ./example/basic && browserify -s ngraph index.js  > bundle.js; cd ../dynamic && browserify -s ngraph index.js  > bundle.js"
   },
   "keywords": [
     "ngraph",
@@ -24,12 +25,13 @@
     "three.trackball": "^0.0.1"
   },
   "peerDependencies": {
-    "three": "^0.x.x"  
+    "three": "^0.x.x"
   },
   "devDependencies": {
     "browserify": "^12.0.1",
     "ngraph.generators": "0.0.3",
     "ngraph.graph": "0.0.12",
+    "npm-install-peers": "^1.0.1-rc.3",
     "query-string": "~0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "url": "https://github.com/anvaka/ngraph.three"
   },
   "dependencies": {
-    "ngraph.forcelayout3d": "0.0.15",
-    "ngraph.merge": "0.0.1",
-    "three": "0.72.0",
-    "three.trackball": "0.0.1"
+    "ngraph.forcelayout3d": "^0.0.15",
+    "ngraph.merge": "^0.0.1",
+    "three.trackball": "^0.0.1"
+  },
+  "peerDependencies": {
+    "three": "^0.x.x"  
   },
   "devDependencies": {
     "browserify": "^12.0.1",


### PR DESCRIPTION
### Description

This pull request changes threejs to be a peer dependency of ngraph.three to fix issues that occur when a consumer is referencing their own version of threejs.

See #4 for details on the issue.